### PR TITLE
Update for recent versions of llvm-pretty(-bc-parser)

### DIFF
--- a/llvm-verifier.cabal
+++ b/llvm-verifier.cabal
@@ -42,8 +42,8 @@ library
     , fingertree
     , haskeline >= 0.7
     , lens
-    , llvm-pretty >= 0.5
-    , llvm-pretty-bc-parser >= 0.1.3.1
+    , llvm-pretty >= 0.10
+    , llvm-pretty-bc-parser >= 0.4
     , mtl
     , saw-core
     , saw-core-aig
@@ -123,8 +123,8 @@ executable lss
     , ansi-wl-pprint
     , cmdargs >= 0.8
     , lens >= 3.9
-    , llvm-pretty >= 0.5
-    , llvm-pretty-bc-parser >= 0.1.2.2
+    , llvm-pretty >= 0.10
+    , llvm-pretty-bc-parser >= 0.4
     , llvm-verifier
     , mtl
     , parsec >= 2.1.0.1
@@ -150,7 +150,7 @@ executable bcdump
     , directory
     , filepath
     , llvm-pretty >= 0.5
-    , llvm-pretty-bc-parser >= 0.1.2.2
+    , llvm-pretty-bc-parser >= 0.4
     , llvm-verifier
     , process
 
@@ -196,7 +196,7 @@ test-suite test-llvm
     , haskeline >= 0.7
     , lens >= 3.9
     , llvm-pretty >= 0.5
-    , llvm-pretty-bc-parser >= 0.1.2.2
+    , llvm-pretty-bc-parser >= 0.4
     , tagged
     , utf8-string
 

--- a/src/Verifier/LLVM/Codebase/Translation.hs
+++ b/src/Verifier/LLVM/Codebase/Translation.hs
@@ -401,7 +401,9 @@ liftStmt stmt =
       sv <- liftValue mtp v
       svl <- traverse liftArgValue tpvl
       return $ Call sv svl Nothing
-    Effect (L.Store (L.Typed tp0 v) addr a) _ -> do
+    -- We don't care if it's atomic, since the symbolic simulator is
+    -- effectively single-threaded
+    Effect (L.Store (L.Typed tp0 v) addr _ a) _ -> do
       tp <- liftMemType' tp0
       tptr <- liftValue tp v
       taddr <- liftTypedValue addr


### PR DESCRIPTION
In particular, the Store instruction gained an "atomic ordering" that we now ignore.

I'm not sure if this means we'll need to wait for an updated version of `llvm-pretty` to make it to Hackage? In other projects it's a git submodule so the story is simpler. 