### PR TITLE
MonadFail instance for the Simulator monad

### DIFF
--- a/src/Verifier/LLVM/Backend.hs
+++ b/src/Verifier/LLVM/Backend.hs
@@ -128,9 +128,9 @@ data SBE m = SBE
     -- normalized to be properly identified as a concrete value.
 
     -- | Interpret the term as a concrete signed integer if it can be.
-  , asSignedInteger :: BitWidth -> SBETerm m -> Maybe Integer
     -- The first int is the bitwidth.  The term should be normalized
     -- to be properly identified as a concrete value.
+  , asSignedInteger :: BitWidth -> SBETerm m -> Maybe Integer
 
     -- | Interpret a pointer as an unsigned integer.
   , asConcretePtr :: SBETerm m -> Maybe Integer

--- a/src/Verifier/LLVM/Backend.hs
+++ b/src/Verifier/LLVM/Backend.hs
@@ -122,10 +122,10 @@ data SBE m = SBE
     -- | Evaluate a typed expression.
   , applyTypedExpr :: TypedExpr (SBETerm m) -> m (SBETerm m)
 
-  , asUnsignedInteger :: BitWidth -> SBETerm m -> Maybe Integer
     -- | Interpret the term as a concrete unsigned integer if it can
     -- be.  The first int is the bitwidth.  The term should be
     -- normalized to be properly identified as a concrete value.
+  , asUnsignedInteger :: BitWidth -> SBETerm m -> Maybe Integer
 
     -- | Interpret the term as a concrete signed integer if it can be.
     -- The first int is the bitwidth.  The term should be normalized


### PR DESCRIPTION
This is necessary to get SAW building with GHC 8.6 since the advent of https://github.com/GaloisInc/saw-core/pull/32, which requires `MonadFail` instances wherever `saw-core` functions are used. 